### PR TITLE
Make starting directory less scary

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,11 +8,13 @@ on:
     paths:
       - pytorch.yml
       - .github/workflows/docker.yml
+      - Dockerfile
   pull_request:
     # This workflow takes a while, let's only run it when we touch relevant files
     paths:
       - pytorch.yml
       - .github/workflows/docker.yml
+      - Dockerfile
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM rapidsai/mambaforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} 
 ARG CUDA_VER
 ARG PYTHON_VER
 
+WORKDIR /home
 COPY pytorch.yml pytorch.yml
 RUN mamba env update -n base --file pytorch.yml \
     && mamba uninstall -y pytorch torchvision \
@@ -15,4 +16,5 @@ RUN mamba env update -n base --file pytorch.yml \
         pytorch \
         torchvision \
         "pytorch-cuda=${CUDA_VER%.*}.*" \
-    && conda clean -afy
+    && conda clean -afy \
+    && rm pytorch.yml


### PR DESCRIPTION
The working directory for our gpu image has a bunch of stuff in it

![image](https://github.com/coiled/examples/assets/11656932/154c6377-6204-40c0-9db4-a76574b71fed)

This PR changes the working directory to `/home` which is empty. Locally I see the following when the changes in this PR:

```
(base) ➜  examples git:(main) ✗ docker run -it 035054310277f0e02dc6ad3b3e5efdcd3db29f7a3d5ef1b2d2955b6a88a3e584 bash
(base) root@e305277cb861:/home# ls -ltra
total 8
drwxr-xr-x 1 root root 4096 Aug 29 15:18 .
drwxr-xr-x 1 root root 4096 Aug 29 15:21 ..
```