### PR TITLE
Use `main` `earthaccess`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,4 +21,4 @@ dependencies:
   - h5netcdf
   - pre-commit
   - pip:
-    - git+https://github.com/jrbourbeau/earthaccess.git@include-store
+    - git+https://github.com/nsidc/earthaccess.git@main


### PR DESCRIPTION
The PR this was pointing to has been merged, let's use the `main` branch of `earthaccess`. A new release should be out soon

xref https://github.com/coiled/examples/issues/28#issuecomment-1718878263