### PR TITLE
Use ``threads_per_worker=-1`` for Coiled Functions

### DIFF
--- a/arxiv-matplotlib.ipynb
+++ b/arxiv-matplotlib.ipynb
@@ -190,7 +190,7 @@
     "@coiled.function(\n",
     "    region=\"us-east-1\",  # Local to data.  Faster and cheaper.\n",
     "    vm_type=\"m6i.xlarge\",\n",
-    "    threads_per_worker=4,\n",
+    "    threads_per_worker=-1,\n",
     ")\n",
     "def extract(filename: str):\n",
     "    \"\"\" Extract and process one directory of arXiv data\n",
@@ -495,7 +495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is just a minor nit. Note it requires the latest `coiled=0.9.36` release (pushed out about an hour ago)