### PR TITLE
Switch GPU docker images to `rapidsai/miniforge-cuda`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG CUDA_VER=11.8.0
 ARG PYTHON_VER=3.10
 ARG LINUX_VER=ubuntu20.04
 
-FROM rapidsai/mambaforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} as base
+FROM rapidsai/miniforge-cuda:cuda${CUDA_VER}-base-${LINUX_VER}-py${PYTHON_VER} as base
 ARG CUDA_VER
 ARG PYTHON_VER
 


### PR DESCRIPTION
`mambaforge-cuda` images are getting deleted soon. see https://github.com/rapidsai/mambaforge-cuda/pull/51