### PR TITLE
Remove temporary Dask pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,10 @@
 name: coiled-examples
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - python=3.10
-  # TODO: Undo version restriction once https://github.com/dmlc/xgboost/issues/11461
-  # has been resolved and released
-  - dask<2025.4.0
+  - dask
   - dask-ml
   - coiled
   - pyarrow


### PR DESCRIPTION
Since the `xgboost=3.0.2` release is out (which contains this fix https://github.com/dmlc/xgboost/pull/11462), we can remove the `dask` version pin. I just confirmed that our XGBoost example works with a fresh environment created from our environment file. 

Closes https://github.com/coiled/examples/issues/55 